### PR TITLE
Fix build errors caused by includes

### DIFF
--- a/include/fnt.h
+++ b/include/fnt.h
@@ -24,7 +24,9 @@
 #ifndef _FNT_H_
 #define _FNT_H_  1
 
-#include <kos.h>
+#include <cstring>
+#include <cstdio>
+#include <dc/pvr.h>
 #include <assert.h>
 #include "sg.h"
 


### PR DESCRIPTION
Seems more likely something is changed in the KOS headers to cause the error, but this allowed it to build for me.

Partial Build Error:
```make[1]: Entering directory '/opt/toolchains/dc/kos-ports/libdcplib/build/libdcplib-2.0.0'
kos-c++   -c ulError.cc -o ulError.o
kos-c++   -c sg.cc -o sg.o
kos-c++   -c fnt.cc -o fnt.o
In file included from include/fnt.h:29,
                 from fnt.cc:24:
include/sg.h:122:13: error: conflicting declaration of C function 'void sgMakeCoordMat4(float (*)[4], const float*, const float*)'
  122 | inline void sgMakeCoordMat4( sgMat4 dst, const sgVec3 xyz, const sgVec3 hpr )
      |             ^~~~~~~~~~~~~~~
include/sg.h:119:13: note: previous declaration 'void sgMakeCoordMat4(float (*)[4], float, float, float, float, float, float)'
  119 | extern void sgMakeCoordMat4 ( sgMat4 dst, const SGfloat x, const SGfloat y, const SGfloat z,
      |             ^~~~~~~~~~~~~~~
include/sg.h:128:13: error: conflicting declaration of C function 'void sgMakeCoordMat4(float (*)[4], const sgCoord*)'
  128 | inline void sgMakeCoordMat4( sgMat4 dst, const sgCoord *src )
      |             ^~~~~~~~~~~~~~~
include/sg.h:119:13: note: previous declaration 'void sgMakeCoordMat4(float (*)[4], float, float, float, float, float, float)'
  119 | extern void sgMakeCoordMat4 ( sgMat4 dst, const SGfloat x, const SGfloat y, const SGfloat z,
      |             ^~~~~~~~~~~~~~~
include/sg.h: In function 'void sgMakeCoordMat4(float (*)[4], const sgCoord*)':
include/sg.h:130:31: error: cannot convert 'const float*' to 'float'
  130 |   sgMakeCoordMat4 ( dst, src->xyz, src->hpr ) ;
      |                          ~~~~~^~~
      |                               |
      |                               const float*
include/sg.h:119:57: note:   initializing argument 2 of 'void sgMakeCoordMat4(float (*)[4], float, float, float, float, float, float)'
  119 | extern void sgMakeCoordMat4 ( sgMat4 dst, const SGfloat x, const SGfloat y, const SGfloat z,
      |                                           ~~~~~~~~~~~~~~^```