### PR TITLE
Update pvr filter type usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Dreamcast PLIB Derivative makefile by Peter Hatch
 # based on
 # addons/libgl Makefile
-# (c)2001 Dan Potter
+# (c)2001 Megan Potter
 #
 
 TARGET = libdcplib.a
@@ -18,5 +18,5 @@ include $(KOS_BASE)/addons/Makefile.prefab
 
 # creates the kos link to the headers
 create_kos_link:
-	rm -f ../include/dcplib
-	ln -s ../libdcplib/include ../include/dcplib
+	rm -f $(KOS_PORTS)/include/dcplib
+	ln -s $(CURDIR)/include $(KOS_PORTS)/include/dcplib

--- a/include/fnt.h
+++ b/include/fnt.h
@@ -60,7 +60,7 @@ public:
   virtual void getBBox (const char *s, float pointsize, float italic, float *left, float *right, float *bot, float *top) {}
   virtual void putch (sgVec3 curpos, float pointsize, float italic, char c, float red, float green, float blue, float alpha) {}
   virtual void puts (sgVec3 curpos, float pointsize, float italic, const char *s, float red, float green, float blue, float alpha) {}
-  virtual void begin (int filter_mode) {}
+  virtual void begin (pvr_filter_mode_t filter_mode) {}
   virtual void end () {}
 
   virtual bool load (const char *fname) { return false; }
@@ -123,7 +123,7 @@ private:
   float v_left [FNTMAX_CHAR];
   float v_right[FNTMAX_CHAR];
 
-  void bind_texture (int filter_mode)
+  void bind_texture (pvr_filter_mode_t filter_mode)
 	{
 	  // PSH OPTIMIZE: it would probably make sense to only compile the header once, and store it as a class variable, instead of recalculating it every time.
 
@@ -208,7 +208,7 @@ public:
 
   void getBBox (const char *s, float pointsize, float italic, float *left, float *right, float *bot, float *top);
 
-  void begin (int filter_mode)
+  void begin (pvr_filter_mode_t filter_mode)
 	{
 	  bind_texture (filter_mode);
 	  bound = true;
@@ -243,7 +243,7 @@ class fntRenderer
 
   float red, green, blue, alpha;
 
-  int filter_mode;
+  pvr_filter_mode_t filter_mode;
 
 public:
   fntRenderer () : pointsize (10.0f), italic (0.0f), red (1.0f), green (1.0f), blue (1.0f), alpha (1.0f), filter_mode (PVR_FILTER_NONE)
@@ -326,11 +326,11 @@ public:
 		*a = alpha;
 	}
 
-  int getFilterMode ()
+  pvr_filter_mode_t getFilterMode ()
 	{
 	  return filter_mode;
 	}
-  void setFilterMode (int fm)
+  void setFilterMode (pvr_filter_mode_t fm)
 	{
 	  filter_mode = fm;
 	}


### PR DESCRIPTION
This type is already present in `pvr_header.h` but is not yet used in the API functions that take them. They need to be updated here before in the kos API because C++ is ok with enum->int but not int->enum.

https://github.com/KallistiOS/KallistiOS/pull/1287 should be merged first as it's in the top of this chain.